### PR TITLE
v0.1.1-alpha : aws configure, kubectl setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 host_vars/*.yml
+vars.yml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ brew install ansible
     - ec2-user
   - ansible_ssh_private_key_file
     - SSH file directory
+- `vars.yml` 수정
+  ```bash
+  cp vars.yml.template vars.yml
+  ```
+  - aws_access_key
+    - your_aws_access_key
+  - aws_secret_key
+    - your_aws_secret_key
+  - region
+    - aws region
+  - cluster_name
+    - eks cluster name
+  - kubectl_version
+    - default ( v1.29.1 )
 
 ---
 ## Check Connection

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -1,0 +1,16 @@
+```bash
+# 루드 디렉토리에서 명령어 수행
+cp host_vars/bastion-1.yml.template host_vars/bastion-1.yml
+
+# 값 넣어주기 
+```
+
+```bash
+# 해당 명령어로 연결 확인
+ansible bastion-1 -m ping -i inventory.ini
+```
+
+```bash
+# 먼저 eks-initial-configuration.yml 에 변수 삽입 ( 개선 필요 )
+ansible-playbook playbooks/eks-initial-configuration.yml -i inventory.ini
+```

--- a/playbooks/eks-initial-configuration.yml
+++ b/playbooks/eks-initial-configuration.yml
@@ -1,0 +1,81 @@
+- name: Configure Bastion Host for EKS
+  hosts: bastion_host
+  vars_files:
+    - ../vars.yml  # 프로젝트 루트 디렉토리에서 vars.yml 파일을 참조
+  tasks:
+    - name: Update all packages
+      become: yes
+      yum:
+        name: '*'
+        state: latest
+
+    - name: Install AWS CLI
+      become: yes
+      yum:
+        name: aws-cli
+        state: present
+
+    - name: Configure AWS CLI
+      become: no
+      shell: >
+        aws configure set aws_access_key_id {{ aws_access_key }} &&
+        aws configure set aws_secret_access_key {{ aws_secret_key }} &&
+        aws configure set region {{ region }}
+      args:
+        executable: /bin/bash
+
+    - name: Download kubectl
+      become: no
+      get_url:
+        url: "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+        dest: /home/{{ ansible_user }}/kubectl
+        mode: '0755'
+
+    - name: Add kubectl to PATH
+      become: no
+      lineinfile:
+        path: /home/{{ ansible_user }}/.bashrc
+        line: 'export PATH=$PATH:/home/{{ ansible_user }}'
+        create: yes
+
+    - name: Apply new PATH environment
+      become: no
+      shell: source /home/{{ ansible_user }}/.bashrc
+      args:
+        executable: /bin/bash
+
+    - name: Verify kubectl installation
+      become: no
+      shell: /home/{{ ansible_user }}/kubectl version --client
+      register: kubectl_output
+
+    - name: Print kubectl version
+      become: no
+      debug:
+        msg: "{{ kubectl_output.stdout }}"
+
+    - name: Update kubeconfig for EKS cluster
+      become: no
+      shell: aws eks --region {{ region }} update-kubeconfig --name {{ cluster_name }}
+      args:
+        executable: /bin/bash
+
+    - name: Verify kubectl current context
+      become: no
+      shell: kubectl config current-context
+      register: current_context
+
+    - name: Print current kubectl context
+      become: no
+      debug:
+        msg: "{{ current_context.stdout }}"
+
+    - name: Verify kubectl get nodes
+      become: no
+      shell: kubectl get nodes
+      register: nodes
+
+    - name: Print kubectl nodes
+      become: no
+      debug:
+        msg: "{{ nodes.stdout }}"

--- a/vars.yml.template
+++ b/vars.yml.template
@@ -1,0 +1,5 @@
+aws_access_key: "your_aws_access_key"
+aws_secret_key: "your_aws_secret_key"
+region: "ap-southeast-1"
+cluster_name: "terraform-cluster"
+kubectl_version: "v1.29.1"


### PR DESCRIPTION
## Summary
1. terraform으로 프로비저닝 한 이후에 bastion host에 연결하여 aws-cli -> aws configure 설정 -> kubectl 설치 -> kubectl context 추가 -> kubectl 명령어로 클러스터 연결 확인
2. playbook에 변수 명시하지 않고 변수파일로 하나로 관리

## Future Advanced
1. eks configuration에 필요한 playbook 추가
2. vault를 사용한 aws access key 쌍 관리 보안 향상