### PR TITLE
v0.1.4-alpha: Remove args from Shell Commands in Playbook

### DIFF
--- a/playbooks/alb-controller-and-istio.yml
+++ b/playbooks/alb-controller-and-istio.yml
@@ -40,13 +40,9 @@
 
     - name: Add EKS Helm repository
       shell: helm repo add eks https://aws.github.io/eks-charts
-      args:
-        executable: /bin/bash
 
     - name: Update Helm repositories
       shell: helm repo update
-      args:
-        executable: /bin/bash
 
     - name: Install AWS Load Balancer Controller using Helm
       shell: |
@@ -55,35 +51,21 @@
           --set clusterName={{ cluster_name }} \
           --set serviceAccount.create=false \
           --set serviceAccount.name=aws-load-balancer-controller
-      args:
-        executable: /bin/bash
 
     - name: Add Istio Helm repository
       shell: helm repo add istio https://istio-release.storage.googleapis.com/charts
-      args:
-        executable: /bin/bash
 
     - name: Update Istio Helm repositories
       shell: helm repo update
-      args:
-        executable: /bin/bash
 
     - name: List Helm repositories
       shell: helm repo list
-      args:
-        executable: /bin/bash
 
     - name: Create Istio namespace
       shell: kubectl create namespace istio-system
-      args:
-        executable: /bin/bash
 
     - name: Install Istio Base using Helm
       shell: helm install istio-base istio/base -n istio-system
-      args:
-        executable: /bin/bash
 
     - name: Install Istiod using Helm
       shell: helm install istiod istio/istiod -n istio-system
-      args:
-        executable: /bin/bash


### PR DESCRIPTION
## Summary
1. playbook에서 args-excutable 제거
2. 

- Ansible의 shell 모듈에서 args 매개변수는 특정 옵션을 명시적으로 전달할 때 사용됨. args를 통해 실행 디렉토리 변경(chdir), 쉘 변경(executable) 등 다양한 설정을 할 수 있는데 , 이는 명령어를 더 명확하게 작성하고 유지 관리하기 쉽게 만듬.

- args를 제외해도 대부분의 경우 명령어는 정상적으로 동작하지만, 특정 상황에서는 args를 사용하는 것이 더 명확하고 안전하다고 함.
- 예를 들어, 작업 디렉토리를 변경하거나 특정 셸을 사용해야 할 때는 args를 사용하는 것이 좋습니다. 이는 코드의 가독성과 유지보수성을 높임​ 
- ([Ansible Docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/shell_module.html))​​ ([Ansible Docs](https://docs.ansible.com/ansible/2.9/modules/shell_module.html))​​ ([DevHub](https://www.typeerror.org/docs/ansible/collections/ansible/builtin/shell_module))​.

- 따라서, 코드의 명확성과 유지 보수성을 고려한다면 args를 포함하는 것이 좋지만 ,  현재의 플레이북에서 args를 제외해도 동작하여 제거함

Q1: Ansible의 shell 모듈에서 args를 사용할 때와 사용하지 않을 때의 구체적인 장단점은 무엇인가?

Q2: Ansible에서 shell 모듈 대신 command 모듈을 사용해야 하는 상황은 언제인가?

Q3: Ansible 플레이북에서 변수 값이 명령어에 안전하게 포함되도록 하기 위한 방법은 무엇인가?

---
## Test Result
[이전PR](https://github.com/ByeongHunKim/Ansible/pull/7) 에서 해당 코드 ( args 제거 ) 로 동작하였음

## Future Advanced
1. eks configuration에 필요한 playbook 추가 : loadbalancer istio에 붙이기 , efs 관련 설정, prometheus + loki with pv, pvc
2. vault를 사용한 aws access key 쌍 관리 보안 향상